### PR TITLE
feat(seo): add SEO, structured data, code splitting, and image a11y

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,30 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/home-deluxe.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Constructora</title>
+        <meta name="theme-color" content="#0E2138" />
+
+        <!-- Primary SEO -->
+        <title>Home Deluxe Constructora | Diseño y Construcción en Buenos Aires</title>
+        <meta name="description" content="Empresa constructora con más de 15 años de experiencia. Diseñamos, proyectamos y construimos viviendas y piscinas en AMBA y Córdoba. +200 obras realizadas." />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href="https://homedeluxe.com.ar/" />
+
+        <!-- Open Graph -->
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://homedeluxe.com.ar/" />
+        <meta property="og:title" content="Home Deluxe Constructora | Diseño y Construcción en Buenos Aires" />
+        <meta property="og:description" content="Empresa constructora con más de 15 años de experiencia. Diseñamos, proyectamos y construimos viviendas y piscinas en AMBA y Córdoba." />
+        <meta property="og:image" content="https://homedeluxe.com.ar/og-image.jpg" />
+        <meta property="og:locale" content="es_AR" />
+        <meta property="og:site_name" content="Home Deluxe Constructora" />
+
+        <!-- Twitter Card -->
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Home Deluxe Constructora | Diseño y Construcción en Buenos Aires" />
+        <meta name="twitter:description" content="Empresa constructora con más de 15 años de experiencia en AMBA y Córdoba." />
+        <meta name="twitter:image" content="https://homedeluxe.com.ar/og-image.jpg" />
+
+        <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-helmet-async": "^3.0.0",
                 "react-icons": "^4.12.0",
                 "react-router-dom": "^6.21.3",
                 "react-slick": "^0.30.2",
@@ -2758,6 +2759,15 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
@@ -3533,6 +3543,26 @@
                 "react": "^18.2.0"
             }
         },
+        "node_modules/react-fast-compare": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+            "license": "MIT"
+        },
+        "node_modules/react-helmet-async": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+            "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "invariant": "^2.2.4",
+                "react-fast-compare": "^3.2.2",
+                "shallowequal": "^1.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/react-icons": {
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
@@ -3736,6 +3766,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+            "license": "MIT"
         },
         "node_modules/sharp": {
             "version": "0.33.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-helmet-async": "^3.0.0",
         "react-icons": "^4.12.0",
         "react-router-dom": "^6.21.3",
         "react-slick": "^0.30.2",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://homedeluxe.com.ar/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://homedeluxe.com.ar/</loc>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://homedeluxe.com.ar/piscinas</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://homedeluxe.com.ar/contact</loc>
+        <changefreq>yearly</changefreq>
+        <priority>0.7</priority>
+    </url>
+</urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,23 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Nav, ScrollToTop } from './components';
-import Constructora from './pages/Constructora';
-import Piscinas from './pages/Piscinas';
-import FormContact from './components/FormContact';
+
+const Constructora = lazy(() => import('./pages/Constructora'));
+const Piscinas = lazy(() => import('./pages/Piscinas'));
+const FormContact = lazy(() => import('./components/FormContact'));
 
 const App = () => {
     return (
         <BrowserRouter>
             <ScrollToTop />
             <Nav />
-            <Routes>
-                <Route path="/" element={<Constructora />} />
-                <Route path="/piscinas" element={<Piscinas />} />
-                <Route path="/contact" element={<FormContact />} />
-            </Routes>
+            <Suspense fallback={null}>
+                <Routes>
+                    <Route path="/" element={<Constructora />} />
+                    <Route path="/piscinas" element={<Piscinas />} />
+                    <Route path="/contact" element={<FormContact />} />
+                </Routes>
+            </Suspense>
         </BrowserRouter>
     );
 };

--- a/src/components/FormContact.tsx
+++ b/src/components/FormContact.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
+import React from 'react';
 import { IoLocationSharp } from 'react-icons/io5';
 import { MdWatchLater, MdAlternateEmail, MdSmartphone } from 'react-icons/md';
-import React from 'react';
+import SEO from './SEO';
 
 const interestOptions = [
     'Vivienda nueva',
@@ -28,6 +29,11 @@ const FormContact = () => {
 
     return (
         <section className="min-h-screen bg-paper pb-20 pt-24">
+            <SEO
+                title="Contacto"
+                description="Contactate con Home Deluxe Constructora. Estamos en Berazategui, Buenos Aires. Tel: +54 11 36821653. Respondemos a la brevedad."
+                canonical="/contact"
+            />
             <div className="mx-auto max-w-7xl px-6">
                 <div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
                     {/* Left column */}

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,51 @@
+import { Helmet } from 'react-helmet-async';
+
+interface SEOProps {
+    title: string;
+    description: string;
+    canonical?: string;
+    ogImage?: string;
+    ogType?: string;
+    jsonLd?: object;
+}
+
+const SITE_URL = 'https://homedeluxe.com.ar';
+const DEFAULT_IMAGE = `${SITE_URL}/og-image.jpg`;
+
+const SEO = ({
+    title,
+    description,
+    canonical,
+    ogImage = DEFAULT_IMAGE,
+    ogType = 'website',
+    jsonLd,
+}: SEOProps) => {
+    const fullTitle = `${title} | Home Deluxe Constructora`;
+    const canonicalUrl = canonical ? `${SITE_URL}${canonical}` : SITE_URL;
+
+    return (
+        <Helmet>
+            <title>{fullTitle}</title>
+            <meta name="description" content={description} />
+            <link rel="canonical" href={canonicalUrl} />
+
+            <meta property="og:type" content={ogType} />
+            <meta property="og:url" content={canonicalUrl} />
+            <meta property="og:title" content={fullTitle} />
+            <meta property="og:description" content={description} />
+            <meta property="og:image" content={ogImage} />
+
+            <meta name="twitter:title" content={fullTitle} />
+            <meta name="twitter:description" content={description} />
+            <meta name="twitter:image" content={ogImage} />
+
+            {jsonLd && (
+                <script type="application/ld+json">
+                    {JSON.stringify(jsonLd)}
+                </script>
+            )}
+        </Helmet>
+    );
+};
+
+export default SEO;

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -44,6 +44,8 @@ export const Card = ({
                     className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
                     src={image}
                     alt={title}
+                    loading="lazy"
+                    decoding="async"
                     style={{
                         background:
                             'linear-gradient(180deg, rgba(14,33,56,0) 50%, rgba(14,33,56,.85))',

--- a/src/components/card/CardAbout.tsx
+++ b/src/components/card/CardAbout.tsx
@@ -33,6 +33,8 @@ export const CardAbout = ({
                 }}
                 src={image}
                 alt={alt}
+                loading="lazy"
+                decoding="async"
             />
             <h4 className="m-0 text-[12px] font-semibold uppercase leading-[1.45] tracking-[.22em] text-paper transition-colors duration-200">
                 {title}

--- a/src/components/carrousel/CarrouselConstru.tsx
+++ b/src/components/carrousel/CarrouselConstru.tsx
@@ -6,10 +6,10 @@ import HeroCarousel from './HeroCarousel';
 import { ArrowRight } from '../icons';
 
 const slides = [
-    { image: house1 },
-    { image: house2 },
-    { image: house4 },
-    { image: house5 },
+    { image: house1, alt: 'Fachada de vivienda moderna construida por Home Deluxe' },
+    { image: house2, alt: 'Casa residencial con diseño contemporáneo' },
+    { image: house4, alt: 'Proyecto de vivienda terminado en Buenos Aires' },
+    { image: house5, alt: 'Construcción residencial de alta calidad' },
 ];
 
 const CarrouselConstru = () => (

--- a/src/components/carrousel/CarrouselPisci.tsx
+++ b/src/components/carrousel/CarrouselPisci.tsx
@@ -6,10 +6,10 @@ import HeroCarousel from './HeroCarousel';
 import { ArrowRight } from '../icons';
 
 const slides = [
-    { image: piscina2 },
-    { image: piscina01 },
-    { image: piscina4 },
-    { image: piscina5 },
+    { image: piscina2, alt: 'Piscina moderna construida por Home Deluxe en Buenos Aires' },
+    { image: piscina01, alt: 'Piscina residencial con acabado premium' },
+    { image: piscina4, alt: 'Proyecto de piscina terminado con revestimiento de calidad' },
+    { image: piscina5, alt: 'Piscina diseñada a medida en AMBA' },
 ];
 
 const CarrouselPisci = () => (

--- a/src/components/carrousel/HeroCarousel.tsx
+++ b/src/components/carrousel/HeroCarousel.tsx
@@ -38,6 +38,8 @@ const HeroCarousel = ({
             {slides.map((slide, i) => (
                 <div
                     key={i}
+                    role="img"
+                    aria-label={slide.alt ?? `Slide ${i + 1}`}
                     style={{
                         position: 'absolute',
                         inset: 0,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <App />
+        <HelmetProvider>
+            <App />
+        </HelmetProvider>
     </React.StrictMode>,
 );

--- a/src/pages/Constructora.tsx
+++ b/src/pages/Constructora.tsx
@@ -7,10 +7,47 @@ import {
     Footer,
     WhatsappChat,
 } from '../components';
+import SEO from '../components/SEO';
+
+const localBusinessJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'LocalBusiness',
+    name: 'Home Deluxe Constructora',
+    description:
+        'Empresa constructora con más de 15 años de experiencia en diseño, proyección y construcción de viviendas y piscinas en AMBA y Córdoba.',
+    url: 'https://homedeluxe.com.ar',
+    telephone: '+54-11-36821653',
+    email: 'constructorahomedeluxe@gmail.com',
+    foundingDate: '2009',
+    address: {
+        '@type': 'PostalAddress',
+        streetAddress: 'Calle 5 4340',
+        addressLocality: 'Berazategui',
+        addressRegion: 'Buenos Aires',
+        addressCountry: 'AR',
+    },
+    areaServed: ['Buenos Aires', 'AMBA', 'Córdoba'],
+    sameAs: [
+        'https://www.facebook.com/constructorahomedeluxe/',
+        'https://www.instagram.com/constructorahomedeluxe',
+    ],
+    openingHoursSpecification: {
+        '@type': 'OpeningHoursSpecification',
+        dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+        opens: '09:00',
+        closes: '18:00',
+    },
+};
 
 const Constructora = () => {
     return (
         <>
+            <SEO
+                title="Diseño y Construcción de Viviendas en Buenos Aires"
+                description="Empresa constructora con más de 15 años de experiencia y 120.000 m² de obras realizadas. Diseñamos, proyectamos y construimos en AMBA y Córdoba."
+                canonical="/"
+                jsonLd={localBusinessJsonLd}
+            />
             <CarrouselConstru />
             <AboutUs />
             <Proyect />

--- a/src/pages/Piscinas.tsx
+++ b/src/pages/Piscinas.tsx
@@ -6,11 +6,41 @@ import {
     WhatsappChat,
     Eyebrow,
 } from '../components';
+import SEO from '../components/SEO';
 import piscina1 from '../assets/image/carrousel/piscinas/piscina1.webp';
+
+const piscinasJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'HomeAndConstructionBusiness',
+    name: 'Home Deluxe — Construcción de Piscinas',
+    description:
+        'Diseño y construcción de piscinas con más de 15 años de experiencia y 200+ obras realizadas en AMBA y Córdoba.',
+    url: 'https://homedeluxe.com.ar/piscinas',
+    telephone: '+54-11-36821653',
+    email: 'constructorahomedeluxe@gmail.com',
+    address: {
+        '@type': 'PostalAddress',
+        streetAddress: 'Calle 5 4340',
+        addressLocality: 'Berazategui',
+        addressRegion: 'Buenos Aires',
+        addressCountry: 'AR',
+    },
+    areaServed: ['Buenos Aires', 'AMBA', 'Córdoba'],
+    sameAs: [
+        'https://www.facebook.com/constructorahomedeluxe/',
+        'https://www.instagram.com/constructorahomedeluxe',
+    ],
+};
 
 const Piscinas = () => {
     return (
         <span id="piscinas" className="relative">
+            <SEO
+                title="Construcción de Piscinas en Buenos Aires"
+                description="Diseño y construcción de piscinas con más de 15 años de experiencia. +200 obras realizadas en AMBA y Córdoba. Calidad, responsabilidad y cumplimiento."
+                canonical="/piscinas"
+                jsonLd={piscinasJsonLd}
+            />
             <CarrouselPisci />
 
             {/* About pools — 2 column grid */}

--- a/src/types/carousel.ts
+++ b/src/types/carousel.ts
@@ -1,3 +1,4 @@
 export interface HeroCarouselSlide {
     image: string;
+    alt?: string;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,4 +13,15 @@ export default defineConfig({
             '@assets': path.resolve(__dirname, './src/assets'),
         },
     },
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks: {
+                    vendor: ['react', 'react-dom', 'react-router-dom'],
+                    carousel: ['react-slick', 'slick-carousel'],
+                    icons: ['react-icons'],
+                },
+            },
+        },
+    },
 });


### PR DESCRIPTION
- Add comprehensive meta tags to index.html (description, OG, Twitter Card, canonical)
- Install react-helmet-async and wrap app in HelmetProvider
- Create reusable SEO component for per-route meta tags
- Add JSON-LD LocalBusiness schema on home page and HomeAndConstructionBusiness on /piscinas
- Create public/robots.txt and public/sitemap.xml
- Implement React.lazy + Suspense for route-based code splitting (vendor/page chunks separated)
- Add manualChunks to vite.config.ts (vendor, carousel, icons)
- Add role=img + aria-label to HeroCarousel slides (background-image a11y)
- Add descriptive alt texts to carousel slides in CarrouselConstru and CarrouselPisci
- Add loading=lazy + decoding=async to Card and CardAbout images
- Extend HeroCarouselSlide type with optional alt field